### PR TITLE
[fix] JWT 토큰 인증 오류 해결

### DIFF
--- a/src/main/java/com/project/deliveryservice/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/project/deliveryservice/common/exception/GlobalExceptionHandler.java
@@ -34,11 +34,4 @@ public class GlobalExceptionHandler {
                 .status(HttpStatus.FORBIDDEN)
                 .body(fail(e.getMessage()));
     }
-
-    @ExceptionHandler(RuntimeException.class)
-    public ResponseEntity<ApiResponse> handleRuntimeException() {
-        return ResponseEntity
-                .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(fail("internal server error"));
-    }
 }

--- a/src/main/java/com/project/deliveryservice/domain/user/entity/Grade.java
+++ b/src/main/java/com/project/deliveryservice/domain/user/entity/Grade.java
@@ -1,7 +1,0 @@
-package com.project.deliveryservice.domain.user.entity;
-
-public enum Grade {
-    NORMAL,
-    VIP,
-    ADMIN
-}

--- a/src/main/java/com/project/deliveryservice/domain/user/entity/Level.java
+++ b/src/main/java/com/project/deliveryservice/domain/user/entity/Level.java
@@ -13,7 +13,7 @@ import org.springframework.security.core.GrantedAuthority;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Level implements GrantedAuthority {
 
-    @Id @GeneratedValue
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String name;
@@ -21,10 +21,10 @@ public class Level implements GrantedAuthority {
     private int policy;
 
     @Enumerated(value = EnumType.STRING)
-    private Grade grade;
+    private Role role;
 
     @Override
     public String getAuthority() {
-        return grade.toString();
+        return role.toString();
     }
 }

--- a/src/main/java/com/project/deliveryservice/domain/user/entity/Role.java
+++ b/src/main/java/com/project/deliveryservice/domain/user/entity/Role.java
@@ -1,0 +1,7 @@
+package com.project.deliveryservice.domain.user.entity;
+
+public enum Role {
+    ROLE_NORMAL,
+    ROLE_VIP,
+    ROLE_ADMIN
+}

--- a/src/main/java/com/project/deliveryservice/domain/user/entity/User.java
+++ b/src/main/java/com/project/deliveryservice/domain/user/entity/User.java
@@ -13,7 +13,7 @@ import lombok.*;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends ExtendedTimeEntity {
-    @Id @GeneratedValue
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(nullable = false, unique = true)

--- a/src/main/java/com/project/deliveryservice/domain/user/repository/LevelRepository.java
+++ b/src/main/java/com/project/deliveryservice/domain/user/repository/LevelRepository.java
@@ -1,0 +1,7 @@
+package com.project.deliveryservice.domain.user.repository;
+
+import com.project.deliveryservice.domain.user.entity.Level;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LevelRepository extends JpaRepository<Level, Long> {
+}

--- a/src/main/java/com/project/deliveryservice/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/project/deliveryservice/jwt/JwtTokenProvider.java
@@ -1,24 +1,15 @@
 package com.project.deliveryservice.jwt;
 
-import com.project.deliveryservice.common.constants.AuthConstants;
-import com.project.deliveryservice.common.exception.ErrorMsg;
+import com.project.deliveryservice.utils.JwtUtils;
 import io.jsonwebtoken.*;
-import io.jsonwebtoken.io.Decoders;
-import io.jsonwebtoken.security.Keys;
-import io.jsonwebtoken.security.SignatureException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.security.Key;
-import java.util.Collections;
-import java.util.Date;
 
 @Component
 public class JwtTokenProvider {
-
-    private static final long ONE_SECONDS = 1000;
-    private static final long ONE_MINUTE = 60 * ONE_SECONDS;
-
+    
     private final Key key;
     private final Key refreshKey;
     private final int expireMin;
@@ -30,55 +21,22 @@ public class JwtTokenProvider {
             @Value("${jwt.expire-min}") int expireMin,
             @Value("${jwt.refresh-expire-min}") int refreshExpireMin) {
 
-        this.key = generateKey(secretKey);
-        this.refreshKey = generateKey(refreshSecretKey);
+        this.key = JwtUtils.generateKey(secretKey);
+        this.refreshKey = JwtUtils.generateKey(refreshSecretKey);
 
         this.expireMin = expireMin;
         this.refreshExpireMin = refreshExpireMin;
     }
 
-    private Key generateKey(String key) {
-        byte[] keyBytes = Decoders.BASE64URL.decode(key);
-        return Keys.hmacShaKeyFor(keyBytes);
-    }
-
-    public String createToken(String email, String authority, Key key, int expireMin) {
-        Date now = new Date();
-        Claims claims = Jwts.claims().setSubject(email);
-        claims.put(AuthConstants.KEY_ROLES, Collections.singleton(authority));
-        return Jwts.builder()
-                .setClaims(claims)
-                .setIssuedAt(now)
-                .setExpiration(new Date(now.getTime() + ONE_MINUTE * expireMin))
-                .signWith(key, SignatureAlgorithm.HS512)
-                .compact();
-    }
-
     public String createAccessToken(String email, String authority) {
-        return createToken(email, authority, key, expireMin);
+        return JwtUtils.createJwtToken(email, authority, expireMin, key);
     }
 
     public String createRefreshToken(String email, String authority) {
-        return createToken(email, authority, refreshKey, refreshExpireMin);
+        return JwtUtils.createJwtToken(email, authority, refreshExpireMin, refreshKey);
     }
 
     public Claims parseClaimsFromRefreshToken(String jwt) {
-        Claims claims;
-        try {
-            claims = Jwts.parserBuilder()
-                    .setSigningKey(refreshKey)
-                    .build()
-                    .parseClaimsJws(jwt)
-                    .getBody();
-        } catch (SignatureException signatureException) {
-            throw new JwtInvalidException(ErrorMsg.DIFFERENT_SIGNATURE_KEY, signatureException);
-        } catch (ExpiredJwtException expiredJwtException) {
-            throw new JwtInvalidException(ErrorMsg.TOKEN_EXPIRED, expiredJwtException);
-        } catch (MalformedJwtException malformedJwtException) {
-            throw new JwtInvalidException(ErrorMsg.TOKEN_MALFORMED, malformedJwtException);
-        } catch (IllegalArgumentException illegalArgumentException) {
-            throw new JwtInvalidException(ErrorMsg.ILLEGAL_TOKEN, illegalArgumentException);
-        }
-        return claims;
+        return JwtUtils.parseClaimsFromJwt(refreshKey, jwt);
     }
 }

--- a/src/main/java/com/project/deliveryservice/utils/JwtUtils.java
+++ b/src/main/java/com/project/deliveryservice/utils/JwtUtils.java
@@ -1,10 +1,24 @@
 package com.project.deliveryservice.utils;
 
 import com.project.deliveryservice.common.constants.AuthConstants;
+import com.project.deliveryservice.common.exception.ErrorMsg;
+import com.project.deliveryservice.jwt.JwtInvalidException;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
 import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.util.StringUtils;
 
+import java.security.Key;
+import java.util.Collections;
+import java.util.Date;
+
 public class JwtUtils {
+
+    private static final long ONE_SECONDS = 1000;
+    private static final long ONE_MINUTE = 60 * ONE_SECONDS;
 
     /**
      *
@@ -16,6 +30,11 @@ public class JwtUtils {
         return JwtUtils.resolveJwtToken(bearerToken);
     }
 
+    /**
+     *
+     * @param bearerToken Grant 타입이 Bearer 인 토큰
+     * @return bearerToken 에서 prefix 를 제거한 실제 토큰
+     */
     public static String resolveJwtToken(String bearerToken) {
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(AuthConstants.BEARER_PREFIX)) {
             return bearerToken.substring(7);
@@ -25,5 +44,62 @@ public class JwtUtils {
 
     private static String getTokenFromHeader(HttpServletRequest request) {
         return request.getHeader(AuthConstants.AUTHORIZATION_HEADER);
+    }
+
+    /**
+     *
+     * @param secretKey Key 인스턴스 생성에 사용될 Base64로 인코딩된 비밀키
+     * @return secretKey 로부터 생성된 Key 인스턴스
+     */
+    public static Key generateKey(String secretKey) {
+        byte[] secretKeyByte = Decoders.BASE64.decode(secretKey);
+        return Keys.hmacShaKeyFor(secretKeyByte);
+    }
+
+    /**
+     *
+     * @param secretKey jwt 토큰 디코딩을 위한 비밀키
+     * @param jwt Claim 을 추출할 jwt 토큰
+     * @return jwt 에서 추출된 claim
+     * @throws AuthenticationException
+     */
+    public static Claims parseClaimsFromJwt(Key secretKey, String jwt) throws AuthenticationException {
+        Claims claims;
+        try {
+            claims = Jwts.parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(jwt)
+                    .getBody();
+        } catch (SignatureException signatureException) {
+            throw new JwtInvalidException(ErrorMsg.DIFFERENT_SIGNATURE_KEY, signatureException);
+        } catch (ExpiredJwtException expiredJwtException) {
+            throw new JwtInvalidException(ErrorMsg.TOKEN_EXPIRED, expiredJwtException);
+        } catch (MalformedJwtException malformedJwtException) {
+            throw new JwtInvalidException(ErrorMsg.TOKEN_MALFORMED, malformedJwtException);
+        } catch (IllegalArgumentException illegalArgumentException) {
+            throw new JwtInvalidException(ErrorMsg.ILLEGAL_TOKEN, illegalArgumentException);
+        }
+        return claims;
+    }
+
+    /**
+     *
+     * @param email jwt 토큰 claim 에 포함될 사용자 이메일
+     * @param authority jwt 토큰 claim 에 포함될 사용자 권한
+     * @param expireMin jwt 토큰 만료 시간 (분 단위)
+     * @param key jwt 토큰 암호화에 사용될 Key 인스턴스
+     * @return jwt 토큰
+     */
+    public static String createJwtToken(String email, String authority, int expireMin, Key key) {
+        Date now = new Date();
+        Claims claims = Jwts.claims().setSubject(email);
+        claims.put(AuthConstants.KEY_ROLES, Collections.singleton(authority));
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + ONE_MINUTE * expireMin))
+                .signWith(key, SignatureAlgorithm.HS512)
+                .compact();
     }
 }

--- a/src/test/java/com/project/deliveryservice/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/project/deliveryservice/domain/auth/controller/AuthControllerTest.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.project.deliveryservice.common.constants.AuthConstants;
 import com.project.deliveryservice.common.exception.ErrorMsg;
 import com.project.deliveryservice.domain.auth.dto.LoginRequest;
-import com.project.deliveryservice.domain.user.entity.Grade;
+import com.project.deliveryservice.domain.user.entity.Role;
 import com.project.deliveryservice.domain.user.entity.Level;
 import com.project.deliveryservice.domain.user.entity.User;
 import com.project.deliveryservice.domain.user.repository.UserRepository;
@@ -14,10 +14,9 @@ import com.project.deliveryservice.jwt.JwtInvalidException;
 import com.project.deliveryservice.jwt.JwtTokenDto;
 import com.project.deliveryservice.jwt.JwtTokenProvider;
 import com.project.deliveryservice.utils.ApiUtils.ApiResponse;
-import io.jsonwebtoken.Claims;
+import com.project.deliveryservice.utils.JwtUtils;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
-import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,9 +29,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
 import java.security.Key;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -54,19 +50,31 @@ class AuthControllerTest {
     @Autowired
     ObjectMapper objectMapper;
     @Value("${jwt.secret}")
-    String secretKey;
+    String secret;
+    @Value("${jwt.refresh-secret}")
+    String refreshSecret;
 
     @MockBean
     JwtTokenProvider mockJwtTokenProvider;
     @MockBean
     UserRepository mockUserRepository;
 
-    private static final int ONE_SECONDS = 1000;
-    private static final int ONE_MINUTE = 60 * ONE_SECONDS;
+    private final String test_email = "test";
+    private final String test_password = "1234";
+    private final String test_authority = "ROLE_ADMIN";
+
+    private Key secretKey;
+    private Key refreshSecretKey;
+
+    @BeforeEach
+    public void setup() {
+        secretKey = JwtUtils.generateKey(secret);
+        refreshSecretKey = JwtUtils.generateKey(refreshSecret);
+    }
 
     User getUser(String email, String password, String authority) {
         Level level = Level.builder()
-                .grade(Grade.valueOf(authority))
+                .role(Role.valueOf(authority))
                 .build();
 
         return User.builder()
@@ -76,38 +84,25 @@ class AuthControllerTest {
                 .build();
     }
 
-    private String createToken(String email, List<String> roles, Date now, int expireMin, Key key) {
-        Claims claims = Jwts.claims().setSubject(email);
-        claims.put(AuthConstants.KEY_ROLES, roles);
-        return Jwts.builder()
-                .setClaims(claims)
-                .setIssuedAt(now)
-                .setExpiration(new Date(now.getTime() + ONE_MINUTE * expireMin))
-                .signWith(key, SignatureAlgorithm.HS512)
-                .compact();
-    }
-
     String getLoginRequest(String email, String password) throws JsonProcessingException {
         LoginRequest loginRequest = new LoginRequest(email, password);
         return objectMapper.writeValueAsString(loginRequest);
     }
 
     private String getAccessToken() {
-        Key key = Keys.hmacShaKeyFor(secretKey.getBytes());
-        return createToken("test", Collections.singletonList("ADMIN"), new Date(), 30, key);
+        return JwtUtils.createJwtToken(test_email, test_authority, 10, secretKey);
     }
 
     private String getRefreshToken() {
-        Key key = Keys.hmacShaKeyFor(secretKey.getBytes());
-        return createToken("test", Collections.singletonList("ADMIN"), new Date(), 10080, key);
+        return JwtUtils.createJwtToken(test_email, test_authority, 30, refreshSecretKey);
     }
 
     @Test
     @DisplayName("존재하지 않는 사용자 정보로 로그인을 요청하면 Forbidden 상태를 반환한다.")
     public void test_01() throws Exception {
 
-        String requestContent = getLoginRequest("test", "1234");
-        when(mockUserRepository.findByEmail("test")).thenReturn(Optional.empty());
+        String requestContent = getLoginRequest(test_email, test_password);
+        when(mockUserRepository.findByEmail(test_email)).thenReturn(Optional.empty());
 
         mockMvc.perform(
                 post("/api/auth/login")
@@ -122,9 +117,9 @@ class AuthControllerTest {
     @DisplayName("일치하지 않는 비밀번호로 로그인 요청을 보내면 Forbidden 상태를 반환한다.")
     public void test_02() throws Exception {
 
-        User user = getUser("test", "1234", "ADMIN");
-        String requestContent = getLoginRequest("test", "12345");
-        when(mockUserRepository.findByEmail("test")).thenReturn(Optional.ofNullable(user));
+        User user = getUser(test_email, test_password, test_authority);
+        String requestContent = getLoginRequest(test_email, "12345");
+        when(mockUserRepository.findByEmail(test_email)).thenReturn(Optional.ofNullable(user));
 
         mockMvc.perform(
                 post("/api/auth/login")
@@ -139,15 +134,15 @@ class AuthControllerTest {
     @DisplayName("유효한 로그인 요청이 들어오면 JwtTokenDto 를 반환한다.")
     public void test_03() throws Exception {
 
-        User user = getUser("test", "1234", "ADMIN");
-        String requestContent = getLoginRequest("test", "1234");
-        when(mockUserRepository.findByEmail("test")).thenReturn(Optional.ofNullable(user));
+        User user = getUser(test_email, test_password, test_authority);
+        String requestContent = getLoginRequest(test_email, test_password);
+        when(mockUserRepository.findByEmail(test_email)).thenReturn(Optional.ofNullable(user));
 
         String accessToken = getAccessToken();
         String refreshToken = getRefreshToken();
-        when(mockJwtTokenProvider.createAccessToken("test", "ADMIN")).thenReturn(accessToken);
-        when(mockJwtTokenProvider.createRefreshToken("test", "ADMIN")).thenReturn(refreshToken);
-        when(mockJwtTokenProvider.parseClaimsFromRefreshToken(refreshToken)).thenReturn(Jwts.claims().setSubject("test"));
+        when(mockJwtTokenProvider.createAccessToken(test_email, test_authority)).thenReturn(accessToken);
+        when(mockJwtTokenProvider.createRefreshToken(test_email, test_authority)).thenReturn(refreshToken);
+        when(mockJwtTokenProvider.parseClaimsFromRefreshToken(refreshToken)).thenReturn(Jwts.claims().setSubject(test_email));
 
         MvcResult mvcResult = mockMvc.perform(
                 post("/api/auth/login")
@@ -193,15 +188,15 @@ class AuthControllerTest {
     @DisplayName("유효한 refreshToken 을 가지고 토큰 재발급을 요청하면 jwtTokenDto 를 반환한다.")
     public void test_06() throws Exception {
 
-        User user = getUser("test", "1234", "ADMIN");
-        when(mockUserRepository.findByEmail("test")).thenReturn(Optional.ofNullable(user));
+        User user = getUser(test_email, test_password, test_authority);
+        when(mockUserRepository.findByEmail(test_email)).thenReturn(Optional.ofNullable(user));
 
         String accessToken = getAccessToken();
         String refreshToken = getRefreshToken();
-        when(mockJwtTokenProvider.createAccessToken("test", "ADMIN")).thenReturn(accessToken);
-        when(mockJwtTokenProvider.createRefreshToken("test", "ADMIN")).thenReturn(refreshToken);
+        when(mockJwtTokenProvider.createAccessToken(test_email, test_authority)).thenReturn(accessToken);
+        when(mockJwtTokenProvider.createRefreshToken(test_email, test_authority)).thenReturn(refreshToken);
         when(mockJwtTokenProvider.parseClaimsFromRefreshToken(refreshToken))
-                .thenReturn(Jwts.claims().setSubject("test"));
+                .thenReturn(Jwts.claims().setSubject(test_email));
 
         MvcResult mvcResult = mockMvc.perform(
                 post("/api/auth/reissue")
@@ -223,8 +218,8 @@ class AuthControllerTest {
     public void test_07() throws Exception {
 
         String accessToken = getAccessToken();
-        User user = getUser("test", "1234", "ADMIN");
-        when(mockUserRepository.findByEmail("test")).thenReturn(Optional.ofNullable(user));
+        User user = getUser(test_email, test_password, test_authority);
+        when(mockUserRepository.findByEmail(test_email)).thenReturn(Optional.ofNullable(user));
         when(mockJwtTokenProvider.parseClaimsFromRefreshToken(accessToken))
                 .thenThrow(new JwtInvalidException(ErrorMsg.DIFFERENT_SIGNATURE_KEY));
 

--- a/src/test/java/com/project/deliveryservice/jwt/JwtAuthenticationProviderTest.java
+++ b/src/test/java/com/project/deliveryservice/jwt/JwtAuthenticationProviderTest.java
@@ -1,11 +1,8 @@
 package com.project.deliveryservice.jwt;
 
-import com.project.deliveryservice.common.constants.AuthConstants;
 import com.project.deliveryservice.common.exception.ErrorMsg;
-import io.jsonwebtoken.Claims;
 
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import com.project.deliveryservice.utils.JwtUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,10 +13,8 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 
+import java.security.Key;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -29,27 +24,20 @@ import static org.junit.jupiter.api.Assertions.*;
 @SpringBootTest
 class JwtAuthenticationProviderTest {
 
-    final int ONE_SECONDS = 1000;
-    final int ONE_MINUTE = 60 * ONE_SECONDS;
+    private final int expireMin = 10;
     @Value("${jwt.secret}")
-    String SECRET;
+    private String secret;
+    private Key secretKey;
+
+    private final String test_email = "test";
+    private final String test_authority = "ROLE_ADMIN";
 
     JwtAuthenticationProvider provider;
 
     @BeforeEach
     public void setup() {
-        provider = new JwtAuthenticationProvider(SECRET);
-    }
-
-    private String createToken(String username, List<String> roles, Date now, int expireMin, String secretKey) {
-        Claims claims = Jwts.claims().setSubject(username);
-        claims.put(AuthConstants.KEY_ROLES, roles);
-        return Jwts.builder()
-                .setClaims(claims)
-                .setIssuedAt(now)
-                .setExpiration(new Date(now.getTime() + ONE_MINUTE * expireMin))
-                .signWith(SignatureAlgorithm.HS256, secretKey.getBytes())
-                .compact();
+        provider = new JwtAuthenticationProvider(secret);
+        secretKey = JwtUtils.generateKey(secret);
     }
 
     @Test
@@ -72,28 +60,28 @@ class JwtAuthenticationProviderTest {
     @DisplayName("다른 비밀키로 만든 토큰을 인자로 authentication 을 호출하면 JwtInvalidException 을 던진다.")
     public void test_03() {
 
-        String invalidSecretKey = "invalidSecretKeyInvalidInvalidInvalid";
-        String invalidToken = createToken("test", Collections.singletonList("ADMIN"), new Date(), 30, invalidSecretKey);
+        String invalidSecret = "invalidSecretKeyInvalidInvalidInvalidinvalidSecretKeyInvalidInvalidInvalidinvalidSecret";
+        Key invalidSecretKey = JwtUtils.generateKey(invalidSecret);
+        String invalidToken = JwtUtils.createJwtToken(test_email, test_authority, expireMin, invalidSecretKey);
         JwtAuthenticationToken authentication = new JwtAuthenticationToken(invalidToken);
 
         Throwable throwable = assertThrows(JwtInvalidException.class, () -> provider.authenticate(authentication));
 
         assertThat(throwable, isA(JwtInvalidException.class));
-        assertThat(throwable.getMessage(), equalTo("signature key is different"));
+        assertThat(throwable.getMessage(), equalTo(ErrorMsg.DIFFERENT_SIGNATURE_KEY));
     }
 
     @Test
     @DisplayName("만료된 토큰을 인자로 authentication 을 호출하면 JwtInvalidException 을 던진다.")
     public void test_04() {
 
-        Date past = new Date(System.currentTimeMillis() - ONE_MINUTE * 10);
-        String invalidToken = createToken("test", Collections.singletonList("ADMIN"), past, 5, SECRET);
+        String invalidToken = JwtUtils.createJwtToken(test_email, test_authority, -expireMin, secretKey);
         JwtAuthenticationToken authentication = new JwtAuthenticationToken(invalidToken);
 
         Throwable throwable = assertThrows(JwtInvalidException.class, () -> provider.authenticate(authentication));
 
         assertThat(throwable, isA(JwtInvalidException.class));
-        assertThat(throwable.getMessage(), equalTo("expired token"));
+        assertThat(throwable.getMessage(), equalTo(ErrorMsg.TOKEN_EXPIRED));
     }
 
     @Test
@@ -124,16 +112,16 @@ class JwtAuthenticationProviderTest {
     @DisplayName("유효한 토큰을 인자로 authentication 을 호출하면 authentication 을 반환한다.")
     public void test_07() {
 
-        String validToken = createToken("test", Collections.singletonList("ADMIN"), new Date(), 30, SECRET);
+        String validToken = JwtUtils.createJwtToken(test_email, test_authority, expireMin, secretKey);
         JwtAuthenticationToken authentication = new JwtAuthenticationToken(validToken);
 
         Authentication authenticated = provider.authenticate(authentication);
 
-        assertThat(authenticated.getPrincipal(), equalTo("test"));
+        assertThat(authenticated.getPrincipal(), equalTo(test_email));
         assertThat(authenticated.getCredentials(), equalTo(""));
         Collection<? extends GrantedAuthority> authorities = authenticated.getAuthorities();
-        for (GrantedAuthority authority : authorities) {
-            assertThat(authority.getAuthority(), equalTo("ADMIN"));
+        for (GrantedAuthority grantedAuthority : authorities) {
+            assertThat(grantedAuthority.getAuthority(), equalTo(test_authority));
         }
     }
 }

--- a/src/test/java/com/project/deliveryservice/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/com/project/deliveryservice/jwt/JwtTokenProviderTest.java
@@ -2,13 +2,8 @@ package com.project.deliveryservice.jwt;
 
 import com.project.deliveryservice.common.constants.AuthConstants;
 import com.project.deliveryservice.common.exception.ErrorMsg;
+import com.project.deliveryservice.utils.JwtUtils;
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.MalformedJwtException;
-import io.jsonwebtoken.io.Decoders;
-import io.jsonwebtoken.security.Keys;
-import io.jsonwebtoken.security.SignatureException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,42 +23,25 @@ class JwtTokenProviderTest {
     @Autowired
     JwtTokenProvider jwtTokenProvider;
     @Value("${jwt.secret}")
-    String secretKey;
+    String secret;
 
-    private Claims parseClaimsFromJwtToken(String jwt) {
-        Claims claims;
-        Key key = Keys.hmacShaKeyFor(Decoders.BASE64.decode(secretKey));
-        try {
-            claims = Jwts.parserBuilder()
-                    .setSigningKey(key)
-                    .build()
-                    .parseClaimsJws(jwt)
-                    .getBody();
-        } catch (SignatureException signatureException) {
-            throw new JwtInvalidException(ErrorMsg.DIFFERENT_SIGNATURE_KEY, signatureException);
-        } catch (ExpiredJwtException expiredJwtException) {
-            throw new JwtInvalidException(ErrorMsg.TOKEN_EXPIRED, expiredJwtException);
-        } catch (MalformedJwtException malformedJwtException) {
-            throw new JwtInvalidException(ErrorMsg.TOKEN_MALFORMED, malformedJwtException);
-        } catch (IllegalArgumentException illegalArgumentException) {
-            throw new JwtInvalidException(ErrorMsg.ILLEGAL_TOKEN, illegalArgumentException);
-        }
-        return claims;
-    }
+    private final String test_email = "test";
+    private final String test_authority = "ROLE_ADMIN";
 
     @Test
     @DisplayName("accessToken 값을 기반으로 생성된 claim 은 토큰과 동일한 값을 갖는다.")
     public void test_01() {
 
-        String jwt = jwtTokenProvider.createAccessToken("test", "Admin");
+        String jwt = jwtTokenProvider.createAccessToken(test_email, test_authority);
+        Key secretKey = JwtUtils.generateKey(secret);
 
-        Claims claims = parseClaimsFromJwtToken(jwt);
+        Claims claims = JwtUtils.parseClaimsFromJwt(secretKey, jwt);
 
-        assertThat(claims.getSubject(), equalTo("test"));
+        assertThat(claims.getSubject(), equalTo(test_email));
         assertThat(claims.get(AuthConstants.KEY_ROLES), isA(List.class));
         List<String> roles = (List) claims.get(AuthConstants.KEY_ROLES);
         for (String role : roles) {
-            assertThat(role, equalTo("Admin"));
+            assertThat(role, equalTo(test_authority));
         }
     }
 
@@ -71,15 +49,15 @@ class JwtTokenProviderTest {
     @DisplayName("refreshToken 값을 기반으로 생성된 claim 은 토큰과 동일한 값을 갖는다.")
     public void test_02() {
 
-        String jwt = jwtTokenProvider.createRefreshToken("test", "Admin");
+        String jwt = jwtTokenProvider.createRefreshToken(test_email, test_authority);
 
         Claims claims = jwtTokenProvider.parseClaimsFromRefreshToken(jwt);
 
-        assertThat(claims.getSubject(), equalTo("test"));
+        assertThat(claims.getSubject(), equalTo(test_email));
         assertThat(claims.get(AuthConstants.KEY_ROLES), isA(List.class));
         List<String> roles = (List) claims.get(AuthConstants.KEY_ROLES);
         for (String role : roles) {
-            assertThat(role, equalTo("Admin"));
+            assertThat(role, equalTo(test_authority));
         }
     }
 
@@ -91,14 +69,14 @@ class JwtTokenProviderTest {
 
         Throwable throwable = assertThrows(JwtInvalidException.class, () -> jwtTokenProvider.parseClaimsFromRefreshToken(invalidRefreshToken));
 
-        assertThat(throwable.getMessage(), equalTo("malformed token"));
+        assertThat(throwable.getMessage(), equalTo(ErrorMsg.TOKEN_MALFORMED));
     }
 
     @Test
     @DisplayName("refreshToken 에서 claim 추출 시 accessToken 이 들어오면 JwtInvalidException 을 던진다.")
     public void test_04() {
 
-        String accessToken = jwtTokenProvider.createAccessToken("test", "ADMIN");
+        String accessToken = jwtTokenProvider.createAccessToken(test_email, test_authority);
 
         Throwable throwable = assertThrows(JwtInvalidException.class, () -> jwtTokenProvider.parseClaimsFromRefreshToken(accessToken));
 

--- a/src/test/java/com/project/deliveryservice/utils/JwtUtilsTest.java
+++ b/src/test/java/com/project/deliveryservice/utils/JwtUtilsTest.java
@@ -1,0 +1,23 @@
+package com.project.deliveryservice.utils;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.security.Key;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+class JwtUtilsTest {
+
+    private final String secret = "asadlkfjlkdjasdkfkladjfkasdfsadfldajaskdjfklsjafkjewjfeiojafksdjfakdfjlksafljsaadsfsdafas";
+    private final Key secretKey = JwtUtils.generateKey(secret);
+
+    @Test
+    @DisplayName("동일한 비밀키가 주어지면 항상 동등한 Key 인스턴스를 생성한다.")
+    void test_01() {
+        Key sameKey = JwtUtils.generateKey(secret);
+
+        assertThat(secretKey, equalTo(sameKey));
+    }
+}


### PR DESCRIPTION
- accessToken 과 refreshToken 의 비밀키 분리하여 토큰 재발급시 accessToken 을 넣으면 에러가 발생하도록 수정
- 중복된 토큰 생성과 디코딩 로직을 유틸로 분리
- 사용자 권한에 'ROLE' 을 prefix 로 추가 -> 스프링 시큐리티에서 권한 검사 시에 'ROLE' 을 자동으로 추가하므로 이와 일치시키기 위함임